### PR TITLE
Add IsoDoc::ExtendedDateFormatter for era + alt numbering

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,4 +7,49 @@ image:https://img.shields.io/github/issues-pr-raw/metanorma/isodoc-i18n.svg["Pul
 image:https://img.shields.io/github/commits-since/metanorma/isodoc-i18n/latest.svg["Commits since latest",link="https://github.com/metanorma/isodoc-i18n/releases"]
 
 
-Internationalisation for Metanorma rendering
+Internationalisation for Metanorma rendering.
+
+`isodoc-i18n` is the shared i18n/l10n base layer used across the
+metanorma flavours. It provides:
+
+* **YAML-driven locale labels** (`IsoDoc::I18n#labels`, `populate`) —
+  per-language label sets loaded from i18n YAML, with cross-file
+  references and Liquid template interpolation.
+* **CLDR-backed l10n of punctuation and spacing** (`#l10n`) — CJK
+  contextual half-width/full-width punctuation, French spacing rules,
+  bidi wrapping for RTL scripts.
+* **Grammatical inflection and ordinals** (`#inflect`, `#inflect_ordinal`)
+  — number/case/gender/person inflection driven by per-language YAML
+  inflection tables, plus CLDR `OrdinalRules` and `SpelloutRules`
+  formatting.
+* **Liquid filter integration** (`IsoDoc::I18n::Liquid`) —
+  `inflect`, `ordinal_num`, `ordinal_word`, etc. registered globally
+  on `Liquid::Environment.default` for use in metanorma templates.
+* **Boolean conjunction list rendering** (`#boolean_conj`) —
+  locale-correct "A, B, and C"-style joins.
+* **Extended date formatting** (`IsoDoc::I18n#date`,
+  `IsoDoc::ExtendedDateFormatter`) — see below.
+
+== Extended date formatting
+
+`isodoc-i18n` ships an extended `strftime`-style date formatter,
+`IsoDoc::ExtendedDateFormatter`, that adds POSIX-flavoured era and
+alternative-numbering surfaces (Japanese era years, kanji spell-out,
+Han digits, Roman months) on top of Ruby's `Date#strftime`. It is the
+engine behind `IsoDoc::I18n#date` and metanorma's
+`<date value="…" format="…"/>` element, and can also be used standalone:
+
+[source,ruby]
+----
+require "isodoc-i18n"
+
+f = IsoDoc::ExtendedDateFormatter.new(lang: "ja", script: "Jpan")
+f.format("2024-09-30", "%EY年%-m月%-d日")        # => "令和6年9月30日"
+
+g = IsoDoc::ExtendedDateFormatter.new(lang: "en", script: "Latn")
+g.format("2024-09-30", "%-d.%Om{roman}.%Y")      # => "30.IX.2024"
+----
+
+Full token reference, calendar dispatch rules, and a comparison with
+`twitter_cldr`, `japanese_calendar`, `ffi-icu`, and other adjacent
+tooling: link:docs/extended-date-format.adoc[`docs/extended-date-format.adoc`].

--- a/docs/extended-date-format.adoc
+++ b/docs/extended-date-format.adoc
@@ -1,0 +1,278 @@
+= Extended date formatting in isodoc-i18n
+
+== Scope
+
+This document covers **only the extensions** introduced by
+`isodoc-i18n` on top of Ruby's standard `Date#strftime`. Specifically:
+
+- Era-year tokens (`%EY`, `%Ey`, `%EC`)
+- Alternative-numbering tokens (`%Om`, `%Od`, `%OY`, `%Oy`)
+- The legacy `%_`-as-literal-space alias kept for backwards compatibility
+
+Everything else — the full set of `%Y`, `%m`, `%d`, `%H`, `%M`, `%S`,
+`%F`, `%T`, `%j`, `%U`, `%W`, `%Z`, `%z`, etc. — is plain Ruby
+`Date#strftime` and is documented at
+https://docs.ruby-lang.org/en/master/strftime_formatting_rdoc.html.
+Read that page first; this document is the *delta*.
+
+The localised name directives (`%B`, `%b`, `%h`, `%A`, `%a`, `%P`,
+`%p`, including their `%^B` etc. uppercase variants) are also part of
+Ruby's standard strftime, but `isodoc-i18n` reroutes them through CLDR
+locale data so the names come out in the configured `lang`/`script`
+rather than in Ruby's hard-coded English. The rerouting is byte-identical
+in surface — the *tokens* are unchanged from Ruby — so it is
+documented in the *Localised names* section below as a pointer rather
+than a re-specification.
+
+
+== Background and dependencies
+
+=== twitter_cldr
+
+`twitter_cldr` is the Ruby port of the
+https://cldr.unicode.org/[Unicode Common Locale Data Repository (CLDR)] — the canonical
+multilingual data set for month names, day names, period markers
+(am/pm), spell-out numbering rules, and so on. Anything in this
+formatter that depends on a locale (the localised-name directives,
+the `spellout` numbering system, the `hanidec`-friendly digit table)
+is ultimately a query against CLDR through twitter_cldr. Repository
+and API docs: https://github.com/twitter/twitter-cldr-rb.
+
+=== japanese_calendar
+
+`japanese_calendar` is a small Ruby gem that adds `Date#era_year` and
+the `%JN`/`%Jy`/`%JH` strftime tokens for the Japanese era
+(*gengō*) calendar. Used by the formatter for `cal=japanese`.
+Repository: https://github.com/junmt/japanese_calendar.
+
+=== POSIX `%E*` / `%O*` modifier convention
+
+The token namespace `%E[YyC]` and `%O[mdYy]` is borrowed from POSIX
+strftime, where `%E` introduces *alternative era representation* and
+`%O` introduces *alternative numeric symbols* for a directive. POSIX
+itself only defines the modifier prefixes; the actual era and
+numbering data is locale-driven. The richest documented expansion is
+GNU strftime, mirrored in Perl as
+https://metacpan.org/dist/POSIX-strftime-GNU[`POSIX::strftime::GNU`]; we follow its intent in
+spirit. Ruby's own `Date#strftime` accepts `%E`/`%O` but treats them
+as no-ops (passing through to the unmodified directive) — claiming
+this surface for actual era/numbering behaviour is the central
+extension here.
+
+=== "Era", concretely
+
+An *era* in this context is a regnal or calendar epoch named by a
+character or short label, with a year count that resets at the start
+of each new epoch. The Japanese calendar is the canonical example
+in metanorma's user base: 令和 (Reiwa, started 2019-05-01), 平成
+(Heisei, 1989-2019), 昭和 (Shōwa, 1926-1989), and so on. Year 6 of
+Reiwa (`令和6`) is calendar-year 2024. The era handler also
+accommodates the Republic of China (Minguo) and Thai Buddhist
+calendars conceptually, where the "era" is a single perpetual count
+that doesn't reset (Minguo year = Gregorian − 1911; Buddhist year =
+Gregorian + 543) — see *Calendar dispatch* below for the current
+wiring status.
+
+
+== Quick reference
+
+[source,ruby]
+----
+require "isodoc-i18n"
+
+f = IsoDoc::ExtendedDateFormatter.new(lang: "ja", script: "Jpan")
+
+f.format("2024-09-30", "%EY年%-m月%-d日")
+# => "令和6年9月30日"
+
+f.format("2024-09-30", "%EY{spellout}年%Om{spellout}月%Od{spellout}日")
+# => "令和六年九月三十日"
+
+g = IsoDoc::ExtendedDateFormatter.new(lang: "en", script: "Latn")
+
+g.format("2024-09-30", "%-d.%Om{roman}.%Y")
+# => "30.IX.2024"
+
+g.format("2024-09-30", "%-d %B %Y")
+# => "30 September 2024"
+----
+
+`format` accepts an ISO-8601 string, a `Date`, a `DateTime`, or a
+`Time` as the first argument.
+
+
+== Token reference
+
+=== Era year — `%EY`, `%Ey`, `%EC`
+
+[cols="1,3"]
+|===
+| Token | Meaning
+
+| `%EY` | Era name + era year (e.g. `令和6` for 2024-09-30 in `cal=japanese`)
+| `%Ey` | Era year only (e.g. `6`)
+| `%EC` | Era name only (e.g. `令和`)
+|===
+
+The argument block selects the numbering system used to render the
+year, and (optionally) the calendar:
+
+[source]
+----
+%EY{numeric}            # 令和6     (default)
+%EY{spellout}           # 令和六
+%EY{cal=japanese}       # 令和6
+%EY{spellout, cal=japanese}
+----
+
+The default calendar is `japanese` when `lang: "ja"`, otherwise
+`gregorian`. Under `cal=gregorian`, `%EY` collapses to the four-digit
+year, `%Ey` to the two-digit year, and `%EC` to an empty string —
+the era surface degrades cleanly for locales without an era
+convention.
+
+For pre-Meiji dates (before 1868), `japanese_calendar.era_year`
+raises; the formatter catches this and falls back to the plain
+Gregorian year.
+
+=== Alternative numbering — `%Om`, `%Od`, `%OY`, `%Oy`
+
+[cols="1,3"]
+|===
+| Token | Meaning
+
+| `%Om` | Month rendered in an alternative numbering system
+| `%Od` | Day rendered in an alternative numbering system
+| `%OY` | Four-digit year in an alternative numbering system
+| `%Oy` | Two-digit year in an alternative numbering system
+|===
+
+The argument block names the numbering system. Supported values:
+
+[cols="1,2,3"]
+|===
+| Keyword | Behaviour | Example for 30
+
+| `numeric` (default) | Latin digits | `30`
+| `latn` | Alias for `numeric` | `30`
+| `spellout` | CLDR `spellout-cardinal` rules in `lang` | `三十` (ja)
+| `hanidec` | Han decimal digits, digit-for-digit | `三〇`
+| `roman` | Roman numerals, uppercase | `XXX`
+| `roman-lower` | Roman numerals, lowercase | `xxx`
+|===
+
+`spellout` and `hanidec` are visually similar for single-digit
+numbers but diverge above 9: `spellout` produces positional kanji
+(`三十` for 30) while `hanidec` is digit-for-digit substitution
+(`三〇`). Pick based on which output the document style requires.
+
+`roman` and `roman-lower` ignore `lang` — the digits are
+language-independent. They are intended for Continental European
+bibliographic styles such as `30.IX.2024` and standards documents
+that quote dates with Roman months as a typographic convention.
+
+=== Localised names — `%B`, `%b`, `%h`, `%A`, `%a`, `%P`, `%p`
+
+These are standard Ruby strftime tokens — see the canonical Ruby
+reference at
+https://docs.ruby-lang.org/en/master/strftime_formatting_rdoc.html.
+`isodoc-i18n` does not change their syntax; it changes their
+*output* by reading the localised month/day/period names from CLDR
+via `twitter_cldr` for the configured `lang`/`script`. The CLDR data
+keys consulted are
+`calendar_data[:months][:format][:wide|:abbreviated]`,
+`calendar_data[:days][:format][:wide|:abbreviated]`, and
+`periods[:am|:pm]`; see the twitter_cldr README at
+https://github.com/twitter/twitter-cldr-rb#calendars-amp-dates for
+the underlying API.
+
+`%^B`, `%^A`, etc. uppercase the localised result. Behaviour is
+byte-identical to the previous `IsoDoc::I18n#date` implementation,
+so existing format strings such as `%-d %B %Y` continue to produce
+the same output.
+
+=== Legacy — `%_`
+
+`%_` is treated as a literal space, preserving the legacy
+`IsoDoc::I18n#date` convention. Note that this overrides Ruby's
+POSIX `%_` flag (which means "space-pad the next directive"); kept
+for backwards compatibility with existing metanorma format strings.
+
+=== Calendar dispatch (extension surface)
+
+The `cal=` argument is a CLDR calendar identifier. Two calendars are
+wired up today:
+
+[cols="1,3"]
+|===
+| Calendar | Status
+
+| `gregorian` | Default for non-Japanese locales. Era tokens degrade as described above.
+| `japanese` | Default for `lang: "ja"`. Backed by `japanese_calendar`.
+|===
+
+The following identifiers are reserved as extension points and raise
+`NotImplementedError` today, with a clear message naming the
+supported set:
+
+`roc`, `buddhist`, `persian`, `islamic`, `indian`, `hebrew`.
+
+These map to CLDR data already shipped by `twitter_cldr`. They are
+documented as future-friendly entry points so user code can be
+written against the eventual API; wiring is a configuration matter,
+not a research project, and will be added on demand.
+
+
+== Comparison of alternatives
+
+When `isodoc-i18n` doesn't fit, these are the gems and standards that
+cover adjacent surface area:
+
+[cols="2,3,3"]
+|===
+| Resource | Scope | Limitation relative to isodoc-i18n
+
+| https://github.com/twitter/twitter-cldr-rb[`twitter_cldr`]
+| CLDR locale data; CLDR-skeleton formatting (`to_additional_s`); spell-out numbering (`to_rbnf_s`)
+| No POSIX `%E*`/`%O*` surface; alternative numbering systems not exposed cleanly per date component
+
+| https://github.com/junmt/japanese_calendar[`japanese_calendar`]
+| `Date#era_year` plus `%JN`/`%Jy`/`%JH` strftime tokens
+| Japan-only; no alternative numbering for the regnal year (we layer twitter_cldr on top)
+
+| https://github.com/sho-h/era_ja[`era_ja`]
+| Like `japanese_calendar`, plus `%K` for the "元年" first-year convention
+| Japan-only; standalone — would duplicate `japanese_calendar`'s surface
+
+| https://github.com/ffi/ffi-icu[`ffi-icu`]
+| Full ICU bindings: native era, numbering systems, locale-aware everything
+| Requires `libicu` system dependency; steep API; heavyweight if you only need date formatting
+
+| https://github.com/ruby-i18n/ruby-cldr[`ruby-cldr`]
+| CLDR data export
+| Data only, no formatting API
+
+| https://metacpan.org/dist/POSIX-strftime-GNU[`POSIX::strftime::GNU` (Perl)]
+| Reference implementation of GNU strftime `%E*`/`%O*` modifiers
+| Perl only; no Ruby port — used here as a design reference
+
+| https://rubygems.org/gems/roman-numerals[`roman-numerals`]
+| Roman numeral conversion
+| No date-formatting surface; isodoc-i18n wraps it for `%Om{roman}`
+
+| https://shopify.github.io/liquid/filters/date[Liquid `date` filter]
+| Vanilla Ruby strftime in Liquid templates
+| No locale, no era, no Roman; a Liquid filter built on this formatter is the wrapper that adds those
+
+| https://liquidjs.com/filters/date.html[LiquidJS `date_to_xmlschema` / `date`]
+| Liquid for JavaScript runtimes; adds `%q` ordinal
+| No era, no alternative numbering; not relevant to a Ruby pipeline but listed for completeness
+
+| https://cldr.unicode.org/[CLDR]
+| The data source `twitter_cldr` re-exposes
+| Data spec, not a formatting API
+
+| https://unicode-org.github.io/icu/[ICU]
+| C/C++ implementation behind `ffi-icu`
+| C library, requires bindings
+|===

--- a/isodoc-i18n.gemspec
+++ b/isodoc-i18n.gemspec
@@ -24,8 +24,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "base64"
   spec.add_dependency "htmlentities", "~> 4.3.4"
+  spec.add_dependency "japanese_calendar"
   spec.add_dependency "liquid", "~> 5"
   spec.add_dependency "metanorma-utils", ">= 1.7.0"
+  spec.add_dependency "roman-numerals"
   spec.add_dependency "twitter_cldr"
 
   spec.add_development_dependency "canon"

--- a/lib/isodoc/date.rb
+++ b/lib/isodoc/date.rb
@@ -1,60 +1,13 @@
 require "date"
+require_relative "extended_date"
 
 module IsoDoc
   class I18n
     def date(value, format)
-      date_i18n(DateTime.iso8601(value)
-        .strftime(convert_date_format(format)))
-    end
-
-    def convert_date_format(fmt)
-      fmt.gsub(/%_/, " ")
-        .gsub(/%(\^?)([BbhPpAa])/, "%\u200c\\1\\2<%\\2>")
-    end
-
-    def date_i18n(val)
-      day_i18n(month_i18n(am_pm_i18n(val)))
-    end
-
-    def am_pm_i18n(val)
-      val.gsub(/%\u200cP<am>/, @cal.periods[:am].downcase)
-        .gsub(/%\u200cP<pm>/, @cal.periods[:pm].downcase)
-        .gsub(/%\u200cp<AM>/, @cal.periods[:am].upcase)
-        .gsub(/%\u200cp<PM>/, @cal.periods[:pm].upcase)
-    end
-
-    def month_i18n(val)
-      { B: :wide, b: :abbreviated, h: :abbreviated }.each do |f, t|
-        @cal_en.calendar_data[:months][:format][t].each do |k, v|
-          m = @cal.calendar_data[:months][:format][t][k]
-          val.gsub!(/%\u200c#{f}<#{v}>/, m)
-          val.gsub!(/%\u200c\^#{f}<#{v}>/, m.upcase)
-        end
-      end
-      val
-    end
-
-    def day_i18n(val)
-      { A: :wide, a: :abbreviated }.each do |f, t|
-        @cal_en.calendar_data[:days][:format][t].each do |k, v|
-          m = @cal.calendar_data[:days][:format][t][k]
-          val.gsub!(/%\u200c#{f}<#{v}>/, m)
-          val.gsub!(/%\u200c\^#{f}<#{v}>/, m.upcase)
-        end
-      end
-      val
+      ExtendedDateFormatter.new(
+        lang: @lang, script: @script,
+        calendar: @cal, calendar_en: @cal_en
+      ).format(value, format)
     end
   end
 end
-
-#   %B - The full month name (``January'')
-#           %^B  uppercased (``JANUARY'')
-#   %b - The abbreviated month name (``Jan'')
-#           %^b  uppercased (``JAN'')
-#   %h - Equivalent to %b
-#   %P - Meridian indicator, lowercase (``am'' or ``pm'')
-#   %p - Meridian indicator, uppercase (``AM'' or ``PM'')
-#   %A - The full weekday name (``Sunday'')
-#           %^A  uppercased (``SUNDAY'')
-#   %a - The abbreviated name (``Sun'')
-#           %^a  uppercased (``SUN'')

--- a/lib/isodoc/extended_date.rb
+++ b/lib/isodoc/extended_date.rb
@@ -1,0 +1,227 @@
+require "date"
+require "twitter_cldr"
+
+module IsoDoc
+  # Extended strftime-style date formatter on top of Ruby's +Date#strftime+.
+  #
+  # Adds three POSIX-flavoured surfaces:
+  #
+  #   %E[YyC](?:\{ARGS\})?  - era year (calendar-aware)
+  #   %O[mdYy](?:\{ARGS\})? - alternative numbering for date components
+  #   %_                    - legacy alias for a literal space (kept for
+  #                           backwards compatibility with IsoDoc::I18n#date)
+  #
+  # The localised name directives (%B, %b, %h, %A, %a, %P, %p) are also
+  # routed through the formatter so they pick up CLDR locale data without
+  # the previous ZWNJ-marker hack in IsoDoc::I18n.
+  #
+  # ARGS is a comma-separated list of either a positional numbering-system
+  # name (numeric, spellout, hanidec, roman, roman-lower) or +key=value+
+  # pairs. The only key currently honoured is +cal=+ (japanese|gregorian);
+  # other CLDR calendar identifiers (roc, buddhist, persian, islamic,
+  # indian, hebrew) are reserved as documented extension points and raise
+  # NotImplementedError today.
+  class ExtendedDateFormatter
+    TOKEN_RX = /
+      %_                                  |
+      %\^?[BbhPpAa]                       |
+      %E[YyC](?:\{[^}]*\})?               |
+      %O[mdYy](?:\{[^}]*\})?
+    /x.freeze
+
+    DAY_KEYS = %i[sun mon tue wed thu fri sat].freeze
+    HANIDEC_FROM = "0123456789".freeze
+    HANIDEC_TO = "〇一二三四五六七八九".freeze
+
+    SUPPORTED_CALENDARS = %i[gregorian japanese].freeze
+
+    def self.format(value, fmt, **opts)
+      new(**opts).format(value, fmt)
+    end
+
+    attr_reader :lang, :script
+
+    def initialize(lang:, script: nil, calendar: nil, calendar_en: nil)
+      @lang = lang.to_s
+      @script = script
+      @cal = calendar || twitter_cldr_calendar
+      @cal_en = calendar_en || TwitterCldr::Shared::Calendar.new(:en)
+    end
+
+    def format(value, fmt)
+      time = coerce(value)
+      tokenise(fmt).map { |kind, payload| render(time, kind, payload) }.join
+    end
+
+    private
+
+    def coerce(value)
+      case value
+      when DateTime, Time then value
+      when Date then value.to_datetime
+      else DateTime.iso8601(value.to_s)
+      end
+    end
+
+    def tokenise(fmt)
+      out = []
+      last = 0
+      fmt.to_enum(:scan, TOKEN_RX).each do
+        m = Regexp.last_match
+        out << [:strftime, fmt[last...m.begin(0)]] if m.begin(0) > last
+        out << [:token, m[0]]
+        last = m.end(0)
+      end
+      out << [:strftime, fmt[last..-1]] if last < fmt.length
+      out
+    end
+
+    def render(time, kind, payload)
+      case kind
+      when :strftime then payload.empty? ? "" : time.strftime(payload)
+      when :token then render_token(time, payload)
+      end
+    end
+
+    def render_token(time, tok)
+      return " " if tok == "%_"
+
+      case tok
+      when /\A%(\^?)([BbhPpAa])\z/
+        render_localised_name(time, Regexp.last_match(1) == "^",
+                              Regexp.last_match(2))
+      when /\A%E([YyC])(?:\{([^}]*)\})?\z/
+        render_era(time, Regexp.last_match(1),
+                   parse_args(Regexp.last_match(2)))
+      when /\A%O([mdYy])(?:\{([^}]*)\})?\z/
+        render_alt_num(time, Regexp.last_match(1),
+                       parse_args(Regexp.last_match(2)))
+      end
+    end
+
+    def render_localised_name(time, upcase, letter)
+      day = DAY_KEYS[time.wday]
+      raw = case letter
+            when "B" then @cal.calendar_data[:months][:format][:wide][time.month]
+            when "b", "h"
+              @cal.calendar_data[:months][:format][:abbreviated][time.month]
+            when "A" then @cal.calendar_data[:days][:format][:wide][day]
+            when "a" then @cal.calendar_data[:days][:format][:abbreviated][day]
+            when "P" then @cal.periods[am_pm(time)].downcase
+            when "p" then @cal.periods[am_pm(time)].upcase
+            end
+      upcase ? raw.upcase : raw
+    end
+
+    def am_pm(time)
+      time.respond_to?(:hour) && time.hour >= 12 ? :pm : :am
+    end
+
+    def render_era(time, letter, args)
+      cal = (args[:cal] || default_calendar).to_sym
+      case cal
+      when :japanese then render_japanese_era(time, letter, args)
+      when :gregorian then render_gregorian_era(time, letter, args)
+      else
+        raise NotImplementedError,
+              "ExtendedDateFormatter: calendar #{cal.inspect} is a " \
+              "documented extension point but is not yet wired up. " \
+              "Supported: #{SUPPORTED_CALENDARS.inspect}."
+      end
+    end
+
+    def render_japanese_era(time, letter, args)
+      require "japanese_calendar"
+      d = time.is_a?(Date) ? time : Date.new(time.year, time.month, time.day)
+      year = format_number(d.era_year, args)
+      case letter
+      when "Y" then "#{d.strftime('%JN')}#{year}"
+      when "y" then year
+      when "C" then d.strftime("%JN")
+      end
+    rescue StandardError
+      case letter
+      when "Y", "y" then format_number(time.year, args)
+      when "C" then ""
+      end
+    end
+
+    def render_gregorian_era(time, letter, args)
+      case letter
+      when "Y" then format_number(time.year, args)
+      when "y" then format_number(time.year % 100, args)
+      when "C" then ""
+      end
+    end
+
+    def render_alt_num(time, letter, args)
+      n = case letter
+          when "m" then time.month
+          when "d" then time.day
+          when "Y" then time.year
+          when "y" then time.year % 100
+          end
+      format_number(n, args)
+    end
+
+    def format_number(num, args)
+      sys = args[:_positional] || args[:numbering] || "numeric"
+      case sys
+      when "numeric", "latn" then num.to_s
+      when "spellout" then spellout(num)
+      when "hanidec" then num.to_s.tr(HANIDEC_FROM, HANIDEC_TO)
+      when "roman" then roman(num)
+      when "roman-lower" then roman(num).downcase
+      else
+        raise ArgumentError,
+              "ExtendedDateFormatter: numbering system #{sys.inspect} not " \
+              "supported. Use one of: numeric, spellout, hanidec, roman, " \
+              "roman-lower."
+      end
+    end
+
+    def spellout(num)
+      num.to_i.localize(twitter_cldr_lang)
+        .to_rbnf_s("SpelloutRules", "spellout-cardinal")
+    end
+
+    def roman(num)
+      require "roman-numerals"
+      RomanNumerals.to_roman(num.to_i)
+    end
+
+    def parse_args(str)
+      out = {}
+      return out if str.nil? || str.empty?
+
+      str.split(",").each do |arg|
+        arg = arg.strip
+        if arg.include?("=")
+          k, v = arg.split("=", 2)
+          out[k.strip.to_sym] = v.strip
+        else
+          out[:_positional] ||= arg
+        end
+      end
+      out
+    end
+
+    def default_calendar
+      @lang == "ja" ? :japanese : :gregorian
+    end
+
+    def twitter_cldr_lang
+      case [@lang, @script]
+      when ["zh", "Hans"] then :"zh-cn"
+      when ["zh", "Hant"] then :"zh-tw"
+      else @lang.to_sym
+      end
+    end
+
+    def twitter_cldr_calendar
+      TwitterCldr::Shared::Calendar.new(twitter_cldr_lang)
+    rescue StandardError
+      TwitterCldr::Shared::Calendar.new(:en)
+    end
+  end
+end

--- a/spec/isodoc/extended_date_spec.rb
+++ b/spec/isodoc/extended_date_spec.rb
@@ -1,0 +1,128 @@
+require "isodoc-i18n"
+
+RSpec.describe IsoDoc::ExtendedDateFormatter do
+  describe "byte-identical fallback for legacy strftime tokens" do
+    it "passes plain Ruby strftime directives through unchanged" do
+      f = described_class.new(lang: "en", script: "Latn")
+      expect(f.format("2011-02-03", "%F")).to eq "2011-02-03"
+      expect(f.format("2011-02-03T09:04:05", "%F %T"))
+        .to eq "2011-02-03 09:04:05"
+      expect(f.format("2011-02-03", "%-m %Y")).to eq "2 2011"
+    end
+
+    it "treats %_ as a literal space (legacy alias)" do
+      f = described_class.new(lang: "en", script: "Latn")
+      expect(f.format("2011-02-03", "%-m%_%Y")).to eq "2 2011"
+      expect(f.format("2011-02-03T09:04:05", "%F%_%T"))
+        .to eq "2011-02-03 09:04:05"
+    end
+
+    it "localises %B/%b/%h month names via twitter_cldr" do
+      en = described_class.new(lang: "en", script: "Latn")
+      ga = described_class.new(lang: "ga", script: "Latn")
+      expect(en.format("2011-02-03", "%B")).to eq "February"
+      expect(en.format("2011-02-03", "%b")).to eq "Feb"
+      expect(en.format("2011-02-03", "%h")).to eq "Feb"
+      expect(ga.format("2011-02-03", "%B")).to eq "Feabhra"
+      expect(ga.format("2011-02-03", "%b")).to eq "Feabh"
+    end
+
+    it "localises %A/%a day names via twitter_cldr" do
+      en = described_class.new(lang: "en", script: "Latn")
+      ga = described_class.new(lang: "ga", script: "Latn")
+      expect(en.format("2011-02-03", "%A")).to eq "Thursday"
+      expect(en.format("2011-02-03", "%a")).to eq "Thu"
+      expect(ga.format("2011-02-03", "%A")).to eq "Déardaoin"
+      expect(ga.format("2011-02-03", "%a")).to eq "Déar"
+    end
+
+    it "upcases %^B / %^A etc." do
+      ga = described_class.new(lang: "ga", script: "Latn")
+      expect(ga.format("2011-02-03", "%^A%_%^B")).to eq "DÉARDAOIN FEABHRA"
+    end
+
+    it "localises %P/%p periods" do
+      en = described_class.new(lang: "en", script: "Latn")
+      ga = described_class.new(lang: "ga", script: "Latn")
+      expect(en.format("2011-02-03T09:04:05", "%p")).to eq "AM"
+      expect(en.format("2011-02-03T21:04:05", "%P")).to eq "pm"
+      expect(ga.format("2011-02-03T09:04:05", "%p")).to eq "R.N."
+      expect(ga.format("2011-02-03T21:04:05", "%P")).to eq "i.n."
+    end
+  end
+
+  describe "Japanese era (%EY / %Ey / %EC)" do
+    let(:f) { described_class.new(lang: "ja", script: "Jpan") }
+
+    it "renders %EY as era name + Arabic-numeric era year by default" do
+      # The metanorma-plateau#138 acceptance target.
+      expect(f.format("2024-09-30", "%EY年%-m月%-d日")).to eq "令和6年9月30日"
+    end
+
+    it "renders %EY{spellout} with kanji era year (legacy JIS shape)" do
+      # Positional kanji throughout (六, 九, 三十) — matches the legacy JIS
+      # `gsub(/(\d+)/) { |n| n.to_rbnf_s(SpelloutRules, spellout-cardinal) }`
+      # post-processor.
+      expect(f.format("2024-09-30",
+                      "%EY{spellout}年%Om{spellout}月%Od{spellout}日"))
+        .to eq "令和六年九月三十日"
+    end
+
+    it "renders %Ey alone as the era year only" do
+      expect(f.format("2024-09-30", "%Ey")).to eq "6"
+      expect(f.format("2024-09-30", "%Ey{spellout}")).to eq "六"
+    end
+
+    it "renders %EC as the era name only" do
+      expect(f.format("2024-09-30", "%EC")).to eq "令和"
+    end
+
+    it "falls back to plain year for pre-Meiji dates" do
+      # japanese_calendar.era_year raises before 1868
+      expect(f.format("1800-01-01", "%EY")).to eq "1800"
+    end
+  end
+
+  describe "alternative numbering (%Om / %Od / %OY / %Oy)" do
+    it "renders Roman months for Continental bibliographic style" do
+      f = described_class.new(lang: "en", script: "Latn")
+      expect(f.format("2024-09-30", "%-d.%Om{roman}.%Y")).to eq "30.IX.2024"
+      expect(f.format("2024-09-30",
+                      "%-d.%Om{roman-lower}.%Y")).to eq "30.ix.2024"
+    end
+
+    it "renders hanidec digits for ja month/day" do
+      f = described_class.new(lang: "ja", script: "Jpan")
+      expect(f.format("2024-09-30", "%Om{hanidec}月%Od{hanidec}日"))
+        .to eq "九月三〇日"
+    end
+
+    it "renders spellout numbering for ja year-of-era" do
+      f = described_class.new(lang: "ja", script: "Jpan")
+      expect(f.format("2024-09-30", "%Oy{spellout}")).to eq "二十四"
+    end
+
+    it "rejects unknown numbering systems with a clear message" do
+      f = described_class.new(lang: "en", script: "Latn")
+      expect { f.format("2024-09-30", "%Om{klingon}") }
+        .to raise_error(ArgumentError, /numbering system/)
+    end
+  end
+
+  describe "calendar dispatch" do
+    it "raises NotImplementedError for documented-but-unwired calendars" do
+      f = described_class.new(lang: "en", script: "Latn")
+      expect { f.format("2024-09-30", "%EY{cal=roc}") }
+        .to raise_error(NotImplementedError, /calendar :roc/)
+      expect { f.format("2024-09-30", "%EY{cal=buddhist}") }
+        .to raise_error(NotImplementedError, /:buddhist/)
+    end
+
+    it "treats gregorian as the default for non-Japanese locales" do
+      f = described_class.new(lang: "en", script: "Latn")
+      expect(f.format("2024-09-30", "%EY")).to eq "2024"
+      expect(f.format("2024-09-30", "%Ey")).to eq "24"
+      expect(f.format("2024-09-30", "%EC")).to eq ""
+    end
+  end
+end


### PR DESCRIPTION
Phase 1a of the extended-date-formatting framework. Adds `IsoDoc::ExtendedDateFormatter` (Japanese era + alternative numbering systems on top of Ruby `Date#strftime`) and reroutes `IsoDoc::I18n#date` through it. Purely additive in this gem — existing format strings produce byte-identical output (verified against `metanorma-jis` 66/66 and `metanorma-plateau` 31/31 spec suites via local-path Gemfile.devel).

Design narrative, scope, and downstream phasing live in metanorma/metanorma-plateau#147. Consumer rewiring in `metanorma-jis` / `metanorma-plateau` is Phase 1b, post-release.

- Refs: metanorma/metanorma-plateau#147 (framework)
- Driver: metanorma/metanorma-plateau#138 (Plateau colophon era year)

## Scope of this PR

- New: `lib/isodoc/extended_date.rb` — `IsoDoc::ExtendedDateFormatter`
- Rewired: `lib/isodoc/date.rb` — `IsoDoc::I18n#date` now a thin wrapper; ZWNJ-marker placeholder hack removed
- Gemspec: adds `japanese_calendar`, `roman-numerals` as direct deps
- Tests: `spec/isodoc/extended_date_spec.rb` (17 examples)
- Docs: `docs/extended-date-format.adoc` (full reference, comparison-of-alternatives table); README summary + teaser

## Test plan

- [x] `bundle exec rspec` — 61 examples, 0 failures (44 pre-existing + 17 new)
- [x] Existing `parses dates` / `parses dates in Irish` specs at `spec/isodoc/base_spec.rb:462-497` pass byte-identical
- [x] `metanorma-jis` spec suite (read-only, Gemfile.devel path-override) — 66/66
- [x] `metanorma-plateau` spec suite (read-only, Gemfile.devel path-override) — 31/31
