### PR TITLE
l10n: skip CJK/FR punctuation inside <tt>: https://github.com/metanorma/mn-samples-plateau/issues/530

### DIFF
--- a/lib/isodoc/l10n.rb
+++ b/lib/isodoc/l10n.rb
@@ -41,6 +41,7 @@ module IsoDoc
 
     def l10n_prep(text, options)
       xml = Nokogiri::XML::DocumentFragment.parse(text)
+      wrap_tt_children_in_esc(xml)
       t = xml.xpath(".//text()").reject { |node| node.text.empty? }
       text_cache = build_text_cache(t, options[:prev], options[:foll])
 
@@ -49,6 +50,19 @@ module IsoDoc
       esc_indices = build_esc_indices(xml, t)
 
       [t, text_cache, xml, options[:prev], options[:foll], esc_indices]
+    end
+
+    # <tt> is an inline code element whose content is by definition Latin /
+    # literal — it must not undergo punctuation localisation. Wrap its
+    # children in <esc> so build_esc_indices skips them; the trailing
+    # <esc>-strip in l10n removes the wrapper afterwards.
+    def wrap_tt_children_in_esc(xml)
+      xml.xpath(".//tt | .//*[local-name()='tt']").each do |tt|
+        next if tt.children.empty?
+        next if tt.children.all? { |c| c.element? && c.name == "esc" }
+
+        tt.inner_html = "<esc>#{tt.inner_html}</esc>"
+      end
     end
 
     # Build set of indices for text nodes within <esc> tags

--- a/spec/isodoc/base_spec.rb
+++ b/spec/isodoc/base_spec.rb
@@ -191,6 +191,38 @@ RSpec.describe IsoDoc::I18n do
     expect(c.l10n(input)).to be_equivalent_to expected
   end
 
+  it "skips punctuation localisation inside <tt> (auto-wraps in <esc>)" do
+    # Regression: https://github.com/metanorma/mn-samples-plateau/issues/530
+    # In a `ja` document, the Latin colon inside `<tt>gml:id</tt>` was being
+    # converted to the fullwidth `：` by `l10n_zh_punct`, because `<tt>`
+    # content was walked as ordinary text. `<tt>` is by definition a
+    # literal/code inline span; its children must be skipped by l10n.
+    c = IsoDoc::I18n.new("ja", "Jpan", i18nyaml: "spec/assets/zh-Hans.yaml")
+
+    # Colon inside <tt> is preserved (the bug case), even though the
+    # surrounding Japanese context would otherwise license conversion.
+    # Surrounding caption-delim colon is still allowed to localise.
+    expect(c.l10n("留意事項 2: <tt>gml:id</tt>の付与ルール"))
+      .to be_equivalent_to "留意事項2： <tt>gml:id</tt>の付与ルール"
+
+    # Other Latin punctuation inside <tt> is likewise preserved.
+    expect(c.l10n("see <tt>foo, bar; baz.</tt> 説明"))
+      .to be_equivalent_to "see <tt>foo, bar; baz.</tt> 説明"
+
+    # <tt> with nested markup: inner markup and inner Latin colon both kept.
+    expect(c.l10n("<tt>a<u>b:c</u>d</tt>"))
+      .to be_equivalent_to "<tt>a<u>b:c</u>d</tt>"
+
+    # Pre-existing <esc> inside <tt> is idempotent — no double-wrap, no leak.
+    expect(c.l10n("<tt><esc>gml:id</esc></tt>"))
+      .to be_equivalent_to "<tt>gml:id</tt>"
+
+    # French: same protection, since l10n_fr shares l10n_prep.
+    c_fr = IsoDoc::I18n.new("fr", "Latn")
+    expect(c_fr.l10n("voir <tt>gml:id</tt> ici"))
+      .to be_equivalent_to "voir <tt>gml:id</tt> ici"
+  end
+
   it "does CJK script mixing localisation" do
     c = IsoDoc::I18n.new("ja", "Jpan", i18nyaml: "spec/assets/zh-Hans.yaml")
     expect(c.l10n("计算机代码： Japan"))


### PR DESCRIPTION
Detail and diagnosis on the source ticket: https://github.com/metanorma/mn-samples-plateau/issues/530.

Latin colon inside `<tt>` was being CJK-localised because `l10n_prep` walked all text nodes regardless of element context. Fix wraps `<tt>` children in `<esc>` so the existing skip mechanism (and the trailing `<esc>` strip) protect literal/code spans, in both `l10n_zh` and `l10n_fr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
